### PR TITLE
Added build flags to allow App Engine use.

### DIFF
--- a/sha256block.go
+++ b/sha256block.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !386,!amd64
+// +build appengine !386,!amd64
 
 // SHA256 block step.
 // In its own file so that a faster assembly or C version

--- a/sha256block_decl.go
+++ b/sha256block_decl.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build 386 amd64
+// +build 386,!appengine amd64,!appengine
 
 package fastsha256
 


### PR DESCRIPTION
This allows the package to run on Google App Engine by telling the goapp build tool not to compile with the assembly. Of course this negates the point of fastsha256 but it does mean that some packages that depend on fastsha256 can also be used.
