### PR TITLE
Allow package to work with App Engine 'goapp' tool.

### DIFF
--- a/sha256block_386.s
+++ b/sha256block_386.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build !appengine
+
 // SHA256 block routine. See sha256block.go for Go equivalent.
 //
 // The algorithm is detailed in FIPS 180-4:

--- a/sha256block_amd64.s
+++ b/sha256block_amd64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build !appengine
+
 //#include "../../../cmd/ld/textflag.h"
 // just use the #define for now since this isn't in the main repo yet.
 #define NOSPLIT 4


### PR DESCRIPTION
This fix prevents the `goapp` tool from attempting to assemble the `*.s` files.
